### PR TITLE
Develop: Added option to either preserve or remove embedded titles of combined notes in final note

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Go to `Tools > Options > Combine notes`
 - `Preserve Location`: The Location (Latitude, Longitude, Altitude) will be added to the new note. Default `false`
 - `Metadata Prefix`: The entered text is output before the metadata (URL, Date, Location).
 - `Metadata Suffix`: The entered text is output after the metadata (URL, Date, Location).
+- `Preserve Source Note Titles`: Titles of source notes will be embedded in new note. Default `true`.
 - `Title of the combined note`: New title of the combined note. Default `Combined note`.
-- `Custom note title`:  New note title with possible variables `{{FIRSTTITLE}}`, `{{LASTTITLE}}`, `{{ALLTITLE}}` and `{{DATE}}`.
+- `Custom note title`: New note title with possible variables `{{FIRSTTITLE}}`, `{{LASTTITLE}}`, `{{ALLTITLE}}` and `{{DATE}}`.
 
 ## Keyboard Shortcuts
 

--- a/src/combineNote.ts
+++ b/src/combineNote.ts
@@ -60,6 +60,10 @@ namespace combineNote {
       const preserveMetadataSuffix = await joplin.settings.value(
         "preserveMetadataSuffix"
       );
+      const preserveSourceNoteTitles = await joplin.settings.value(
+        "preserveSourceNoteTitles"
+      );
+
       const addCombineDate = await joplin.settings.value("addCombineDate");
       const dateFormat = await joplin.settings.globalValue("dateFormat");
       const timeFormat = await joplin.settings.globalValue("timeFormat");
@@ -86,7 +90,9 @@ namespace combineNote {
             "altitude",
           ],
         });
-        newNoteBody.push("# " + note.title + "\n");
+        if (preserveSourceNoteTitles === true) {
+          newNoteBody.push("# " + note.title + "\n");
+        }
         titles.push(note.title);
 
         // Preserve metadata

--- a/src/locales/de_DE.json
+++ b/src/locales/de_DE.json
@@ -15,6 +15,8 @@
   "settings.preserveMetadataPrefixDescription": "Präfix für den Abschnitt Metadaten.",
   "settings.preserveMetadataSuffix": "Metadata-Suffix",
   "settings.preserveMetadataSuffixDescription": "Suffix für den Abschnitt Metadaten.",
+  "settings.preserveSourceNoteTitles": "Behalten sie die titel der Quellnotizen bei",
+  "settings.preserveSourceNoteTitlesDescription": "Behält die titel ausgewählter Notizen im kombinierten Notiztext bei",
   "settings.combinedNoteTitle": "Titel der Kombinierten Notiz",
   "settings.combinedNoteTitleValueDefault": "Kombinierte Notiz",
   "settings.combinedNoteTitleValueCombined": "Kombination aus allen Notiztitel",

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -15,6 +15,8 @@
   "settings.preserveMetadataPrefixDescription": "Prefix for the Metadata section.",
   "settings.preserveMetadataSuffix": "Metadata Suffix",
   "settings.preserveMetadataSuffixDescription": "Suffix for the Metadata section.",
+  "settings.preserveSourceNoteTitles": "Preserve source note titles",
+  "settings.preserveSourceNoteTitlesDescription": "Preserves titles of selected notes within the combined note body",
   "settings.combinedNoteTitle": "Title of the combined note",
   "settings.combinedNoteTitleValueDefault": "Combined note",
   "settings.combinedNoteTitleValueCombined": "Combination of all note titles",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -89,6 +89,15 @@ export namespace settings {
         description: i18n.__("settings.preserveMetadataSuffixDescription"),
       },
 
+      preserveSourceNoteTitles: {
+        value: true,
+        type: SettingItemType.Bool,
+        section: "combineNoteSection",
+        public: true,
+        label: i18n.__("settings.preserveSourceNoteTitles"),
+        description: i18n.__("settings.preserveSourceNoteTitlesDescription"),
+      },
+
       combinedNoteTitle: {
         value: "default",
         type: SettingItemType.String,


### PR DESCRIPTION
Added an option boolean to filter out source note titles being embedded in the combined note.
I think I was able to cover most of the areas of change:
combineNote.ts
de_DE.json
de_US.json
settings.ts
README.md
Unit and functional testing seemed good.  No updating of the version number. I used Google Translate for the German translation.  Let me know if you see anything significant missing.